### PR TITLE
manage entrypoint

### DIFF
--- a/ov
+++ b/ov
@@ -23,7 +23,7 @@ OV_GID=$(id -g)
 
 COMPOSE="docker compose -f docker-compose.yml -f ov_wag/docker-compose.yml"
 DEPLOY="-f deploy.yml"
-MANAGE="run wagtail python3 manage.py"
+MANAGE="run -it --entrypoint python wagtail manage.py"
 
 if [ -z $1 ]; then
   echo -e $HELP


### PR DESCRIPTION
# Fix `./ov manage`
Because [ov_way PR36](https://github.com/WGBH-MLA/ov_wag/pull/36) sets the default `wagtail` image's `ENTRYPOINT` to `docker_entrypoints/deploy.sh`

The `$MANAGE` string now:
- Adds `-it` to enable an interactive terminal through docker
- Overrides `--entrypoint` to use `python`