### PR TITLE
Sync milestone data with sync-milestones.json

### DIFF
--- a/sync-milestones.json
+++ b/sync-milestones.json
@@ -1,0 +1,24 @@
+[
+  {
+    "repositories": [
+      "WGBH-MLA/ov_deploy",
+      "WGBH-MLA/ov_wag",
+      "WGBH-MLA/ov-frontend"
+    ],
+    "milestones": [
+      {
+        "previousTitles": ["v0.1.0"],
+        "title": "v0.1.0 Demo 🏗️",
+        "description": "# Demo deployment\nProof of concept, deployed to Rancher. Including:\n- [x] Deploy tools\n- [x] Config files",
+        "due_on": "2022-07-13T23:59:59Z"
+      },
+      {
+        "previousTitles": ["v0.2.0"],
+        "title": "v0.2.0 Deploy 🌇",
+        "state": "open",
+        "description": "# Deploy\n#### *The self-titled album*\n\nIncludes:\n- [ ] deploy documentation\n- [ ] `nginx` image\n- [ ] `utility` image",
+        "due_on": "2022-08-01T23:59:59Z"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
# Sync milestones
With PR #16, sync milestones across `ov-*` repos.

Using [github-sync-labels-milestones](https://github.com/Xiphe/github-sync-labels-milestones/)

## Usage
`github-sync-labels-milestones -t $GITHUB_TOKEN -c sync-labels.json`