### PR TITLE
Migrate to using upstream nginx image directly

### DIFF
--- a/ov-nginx/Dockerfile
+++ b/ov-nginx/Dockerfile
@@ -1,3 +1,3 @@
-FROM foggbh/ov-nginx:latest
+FROM nginx:latest
 
 COPY ./nginx.conf /etc/nginx/nginx.conf

--- a/ov-nginx/nginx.conf
+++ b/ov-nginx/nginx.conf
@@ -1,12 +1,12 @@
 events {
-  worker_connections  4096;  ## Default: 1024
+  worker_connections  4096; # Default: 1024
 }
 
 http {
   server {
     listen 80 default_server;
     location / {
-      proxy_pass      http://ov-frontend:3000;
+      proxy_pass http://ov-frontend:3000;
     }
   }
 }


### PR DESCRIPTION
# ov-nginx
- Migrate `ov-nginx` image to use `nginx` image directly
- Copy in conf file to image
- Pushed to [docker hub](https://hub.docker.com/r/wgbhmla/ov-nginx)

## `nginx.conf`
Because the new image contains the `nginx.conf` file, there is no longer any need to mount the config file in Rancher, unless a different configuration is wanted.

Closes #14 